### PR TITLE
Use nproc to count processors

### DIFF
--- a/zramstart
+++ b/zramstart
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-num_cpus=$(grep -c processor /proc/cpuinfo)
+num_cpus=$(nproc)
 [ "$num_cpus" != 0 ] || num_cpus=1
 
 last_cpu=$((num_cpus - 1))


### PR DESCRIPTION
Some processor have the word "processor" lowercased in their name, like the Intel Celeron 900 of EeePC.
The nproc command does this job, let's use it!
